### PR TITLE
RDKB-61922: RDK Coverity cleanup for dmcli

### DIFF
--- a/source/MsgBusTestServer/cosa_MsgBusTest_dml.c
+++ b/source/MsgBusTestServer/cosa_MsgBusTest_dml.c
@@ -82,7 +82,8 @@ BOOL MsgBusTest_SetParamStringValue(ANSC_HANDLE hInsContext, char* ParamName, ch
     ERR_CHK(rc);
     if ((!ind) && (rc == EOK))
     {
-	AnscCopyString(ParamString, strValue);
+        memset(ParamString, 0, sizeof(ParamString));
+        strncpy(ParamString, strValue, (sizeof(ParamString) - 1));
 	   
         return TRUE;
     }

--- a/source/MsgBusTestServer/ssp_main.c
+++ b/source/MsgBusTestServer/ssp_main.c
@@ -201,7 +201,7 @@ int main(int argc, char* argv[])
     {
         if ((strcmp(argv[idx], "-subsys") == 0))
         {
-            AnscCopyString(g_Subsystem, argv[idx+1]);
+            strncpy(g_Subsystem, argv[idx+1], (sizeof(g_Subsystem) - 1));
         }
         else if (strcmp(argv[idx], "-c") == 0)
         {


### PR DESCRIPTION
Reason for change: Address Coverity issues in MsgBusTestServer executable
Test Procedure: Run MsgBusTestServer and MsgBusTestClient and check for errors
Risks: Low
Priority: P1